### PR TITLE
Install uv in prek workflow

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -26,8 +26,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
       - name: Run prek
-        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+        uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
         with:
           extra-args: "${{ inputs.extra-args }}"
         env:

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          ignore-nothing-to-cache: true
 
       - name: Run prek
         uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5


### PR DESCRIPTION
By install uv in the prek workflow it will be possible to run pre-commit hooks that install project specific dependency-groups. This help keeping the project and pre-commit dependency in sync.

- [x] Linting passes
- [x] Tests are added and passing
- [x] Documentation is updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated linting/check workflow to install the required tooling before running checks.
  * Refreshed the workflow’s pinned action version for better reliability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->